### PR TITLE
Fix cherrypy config.update call

### DIFF
--- a/app.py
+++ b/app.py
@@ -141,13 +141,12 @@ if __name__ == '__main__':
     cherrypy.server.max_request_body_size = 0
     cherrypy.server.socket_timeout = 60
 
+    cherrypy.config.update({'server.socket_host': '127.0.0.1',
+                            'server.socket_port': 8080})
+
     cherrypy.tree.mount(GeoParser(), '/', main_conf)
     cherrypy.tree.mount(Status(), '/status', status_conf)
     cherrypy.quickstart(Search(), '/search', search_conf)
-
-    cherrypy.config.update({'server.socket_host': '127.0.0.1',
-                            'server.socket_port': 8080,
-                            })
 
     cherrypy.engine.start()
     cherrypy.engine.block()


### PR DESCRIPTION
Changing the port or IP won't take effect unless the cherrypy.config.update call happens before quickstart is run.
